### PR TITLE
Add rudimentary routing

### DIFF
--- a/lib/rulers.rb
+++ b/lib/rulers.rb
@@ -1,14 +1,53 @@
-require 'rulers/version'
 require 'rulers/array'
 require 'rulers/object'
+require 'rulers/routing'
+require 'rulers/version'
 
 module Rulers
   class Application
     def call(env)
-      [200, {'Content-Type' => 'text/html'},
-        ['Hello from Ruby on Rulers!']]
+      klass, act = get_controller_and_action(env)
+      controller = klass.new(env)
+      text = controller.send(act)
+      [200, {'Content-Type' => 'text/html'}, [text]]
+    rescue ControllerNotFoundError => e
+      server_error(subject: e.message)
+    rescue FileNotFoundError
+      [404, {'Content-Type' => 'text/html'}, []]
+    rescue NoMethodError
+      msg = "Action <code>#{act}</code> not found in <code>#{klass}</code>"
+      server_error(subject: msg)
+    end
+
+    private
+
+    def server_error(subject:, body: nil)
+      [500, {'Content-Type' => 'text/html'}, [
+        %(
+          <html>
+            <head>
+              <title>Oh no!!! Server Error!</title>
+            </head>
+            <body>
+              <h1>#{subject}</h1>
+              <p>#{body}</p>
+            </body>
+          </html>
+        )
+        ]]
     end
   end
 
-  class Error < StandardError; end
+  class Controller
+    def initialize(env)
+      @env = env
+    end
+
+    def env
+      @env
+    end
+  end
+
+  class ControllerNotFoundError < StandardError; end
+  class FileNotFoundError < StandardError; end
 end

--- a/lib/rulers/routing.rb
+++ b/lib/rulers/routing.rb
@@ -1,0 +1,14 @@
+module Rulers
+  class Application
+    def get_controller_and_action(env)
+      _, cont, action, after = env["PATH_INFO"].split('/', 4)
+      raise FileNotFoundError if cont == 'Favicon.ico'
+      cont = 'home' if cont.blank?
+      action = 'index' if action.blank?
+      cont = cont.capitalize + "Controller"
+      [Object.const_get(cont), action]
+    rescue NameError
+      raise ControllerNotFoundError, "Controller <code>#{cont}</code> not found"
+    end
+  end
+end

--- a/lib/rulers/version.rb
+++ b/lib/rulers/version.rb
@@ -1,3 +1,3 @@
 module Rulers
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
- converts a path like "foo/bar" into a request for `FooController#bar`
- default action is index ("foo" requests `FooController#index`)
- default controller is HomeController ("" requests 
`HomeController#index`)
- doesn't handle nested routes ("foo/bar/baz" will still go to 
`FooController#bar`)
- currently 404s on requests for favicon.ico (to silence errors for time 
being)